### PR TITLE
Fullscreen support for MacOS

### DIFF
--- a/Terminal/Source/CocoaWindow.mm
+++ b/Terminal/Source/CocoaWindow.mm
@@ -572,7 +572,10 @@ namespace BearLibTerminal
     
     void CocoaWindow::SetFullscreen(bool fullscreen)
     {
-        LOG(Error, "CocoaWindow::SetFullscreen: not yet implemented");
+        bool is_fullscreen = ([m_impl->m_window styleMask] & NSFullScreenWindowMask) == NSFullScreenWindowMask;
+        if (is_fullscreen != fullscreen) {
+            [m_impl->m_window toggleFullScreen: nil];
+        }
     }
     
     void CocoaWindow::SetCursorVisibility(bool visible)

--- a/Terminal/Source/Terminal.cpp
+++ b/Terminal/Source/Terminal.cpp
@@ -655,6 +655,7 @@ namespace BearLibTerminal
 		if (updated.window_fullscreen != m_options.window_fullscreen)
 		{
 			// XXX: It's not always possible to change fullscreen state in runtime.
+			m_vars[TK_FULLSCREEN] = updated.window_fullscreen;
 			m_window->SetFullscreen(updated.window_fullscreen);
 		}
 


### PR DESCRIPTION
Basic fulllscreen support, tested on MacOS Catalina 10.15.7.

Also fixes a bug where TK_FULLSCREEN was not being updated when setting `window: fullscreen=true`,
which differed from the ALT+ENTER codepath.