### PR TITLE
Install target for BearLibTerminal

### DIFF
--- a/Terminal/CMakeLists.txt
+++ b/Terminal/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
 
+include(GNUInstallDirs)
+
 if (UNIX AND NOT APPLE)
 	set(LINUX TRUE)
 endif()
@@ -95,3 +97,5 @@ elseif (APPLE)
 		BUILD_WITH_INSTALL_RPATH TRUE
 		INSTALL_NAME_DIR "@executable_path")
 endif()
+
+install(TARGETS BearLibTerminal)


### PR DESCRIPTION
I was trying to build this on my system (NixOS) and wanted an install target so all of the existing tooling worked. The existing tooling also makes use of GNUInstallDirs to set the installation location.

I thought this might be helpful for others as well.