### PR TITLE
Added pkg-config file

### DIFF
--- a/BearLibTerminal.pc
+++ b/BearLibTerminal.pc
@@ -1,0 +1,6 @@
+Name: BearLibTerminal
+Description: rogue-like game library
+Version: 0.12
+URL: https://github.com/cfyzium/bearlibterminal
+Libs: -lBearLibTerminal
+Cflags: -D_GNU_SOURCE -D_DEFAULT_SOURCE


### PR DESCRIPTION
Added a super basic .pc file, so that scripts/build-systems that use pkg-config to find dependencies can find it. Unfortunately I don't know how to use Cmake, so all I can contribute is the file itself. It should go under $PREFIX/$LIBDIR/pkgconfig/. Sorry I can only contribute a file, but cmake looks like gibberish to my =P